### PR TITLE
CC-6894 Added CurrencyFacadeInterface::getCurrentCurrencyIsoCode()

### DIFF
--- a/src/Spryker/Zed/Currency/Business/CurrencyBusinessFactory.php
+++ b/src/Spryker/Zed/Currency/Business/CurrencyBusinessFactory.php
@@ -8,6 +8,9 @@
 namespace Spryker\Zed\Currency\Business;
 
 use Spryker\Shared\Currency\Builder\CurrencyBuilder;
+use Spryker\Shared\Kernel\Store;
+use Spryker\Zed\Currency\Business\Reader\CurrencyIsoCodeReader;
+use Spryker\Zed\Currency\Business\Reader\CurrencyIsoCodeReaderInterface;
 use Spryker\Zed\Currency\CurrencyDependencyProvider;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 
@@ -26,6 +29,14 @@ class CurrencyBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
+     * @return \Spryker\Zed\Currency\Business\Reader\CurrencyIsoCodeReaderInterface
+     */
+    public function createCurrencyIsoCodeReader(): CurrencyIsoCodeReaderInterface
+    {
+        return new CurrencyIsoCodeReader($this->getStore());
+    }
+
+    /**
      * @return \Spryker\Shared\Kernel\Store
      */
     protected function getStore()
@@ -39,6 +50,14 @@ class CurrencyBusinessFactory extends AbstractBusinessFactory
     protected function getInternationalization()
     {
         return $this->getProvidedDependency(CurrencyDependencyProvider::INTERNATIONALIZATION);
+    }
+
+    /**
+     * @return \Spryker\Shared\Kernel\Store
+     */
+    public function getStore(): Store
+    {
+        return $this->getProvidedDependency(CurrencyDependencyProvider::STORE);
     }
 
 }

--- a/src/Spryker/Zed/Currency/Business/CurrencyFacade.php
+++ b/src/Spryker/Zed/Currency/Business/CurrencyFacade.php
@@ -43,4 +43,18 @@ class CurrencyFacade extends AbstractFacade implements CurrencyFacadeInterface
         return $this->getFactory()->createCurrencyBuilder()->getCurrent();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getCurrentCurrencyIsoCode(): string
+    {
+        return $this->getFactory()
+            ->createCurrencyIsoCodeReader()
+            ->getCurrentCurrencyIsoCode();
+    }
+
 }

--- a/src/Spryker/Zed/Currency/Business/CurrencyFacade.php
+++ b/src/Spryker/Zed/Currency/Business/CurrencyFacade.php
@@ -56,5 +56,4 @@ class CurrencyFacade extends AbstractFacade implements CurrencyFacadeInterface
             ->createCurrencyIsoCodeReader()
             ->getCurrentCurrencyIsoCode();
     }
-
 }

--- a/src/Spryker/Zed/Currency/Business/CurrencyFacadeInterface.php
+++ b/src/Spryker/Zed/Currency/Business/CurrencyFacadeInterface.php
@@ -35,4 +35,13 @@ interface CurrencyFacadeInterface
      */
     public function getCurrent();
 
+    /**
+     * Specification:
+     * - Gets the default currency ISO code for current store.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getCurrentCurrencyIsoCode(): string;
 }

--- a/src/Spryker/Zed/Currency/Business/Reader/CurrencyIsoCodeReader.php
+++ b/src/Spryker/Zed/Currency/Business/Reader/CurrencyIsoCodeReader.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Currency\Business\Reader;
+
+use Spryker\Shared\Kernel\Store;
+
+class CurrencyIsoCodeReader implements CurrencyIsoCodeReaderInterface
+{
+    /**
+     * @var \Spryker\Shared\Kernel\Store
+     */
+    protected $store;
+
+    /**
+     * @param \Spryker\Shared\Kernel\Store $store
+     */
+    public function __construct(Store $store)
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentCurrencyIsoCode(): string
+    {
+        return $this->store->getCurrencyIsoCode();
+    }
+}

--- a/src/Spryker/Zed/Currency/Business/Reader/CurrencyIsoCodeReaderInterface.php
+++ b/src/Spryker/Zed/Currency/Business/Reader/CurrencyIsoCodeReaderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Currency\Business\Reader;
+
+interface CurrencyIsoCodeReaderInterface
+{
+    /**
+     * @return string
+     */
+    public function getCurrentCurrencyIsoCode(): string;
+}


### PR DESCRIPTION
Branch: backport/cc-6894/currency-2.2.0
Ticket: https://spryker.atlassian.net/browse/CC-6894
Epic Ticket: https://spryker.atlassian.net/browse/CC-6891

Target Version: 2.2.0

https://release.spryker.com/release/hotfix?pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fcurrency%2Fpull%2F1

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Currency               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module ProductLabelStorage

##### Change log

Improvements

- Introduced `CurrencyFacade::getCurrentCurrencyIsoCode()`.